### PR TITLE
feature/SymbolToPrimitive, adds methods for convertion:

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,41 @@ class MyArray {
       }
     }
   }
+
+  [Symbol.toPrimitive](hint) {
+    function concatenateProperties() {
+      let newString = '';
+
+      if (this.length !== 0) {
+        newString = `${Object.keys(this)[0]}: ${Object.values(this)[0]}`;
+
+        for (let i = 1; i < 5; i++) {
+          newString = `${newString}, ${Object.keys(this)[i]}: ${Object.values(this)[i]}`;
+        }
+      }
+      return `First 5 properties are - ${newString}`;
+    }
+
+    function sumProperties() {
+      let sum = 0;
+
+      for (let i = 0; i < this.length; i++) {
+        if (typeof Object.values(this)[i] === 'number') {
+          sum += Object.values(this)[i];
+        }
+      }
+      return sum;
+    }
+
+    switch (hint) {
+    case 'string':
+      return concatenateProperties.call(this);
+    case 'number':
+      return sumProperties.call(this);
+    default:
+      return 'WTF?!';
+    }
+  }
 }
 
 // ===================== PUSH =====================

--- a/src/tests/instance.test.js
+++ b/src/tests/instance.test.js
@@ -40,7 +40,7 @@ describe('tests for instance', () => {
     };
     Reflect.ownKeys(MyArray.prototype).forEach(item => delete declaratedMethods[item]);
     expect(declaratedMethods).toEqual({});
-    expect(Reflect.ownKeys(MyArray.prototype).length).toBe(12);
+    expect(Reflect.ownKeys(MyArray.prototype).length).toBe(13);
   });
 
   test('Class has only declarated static method and common like \'length\', \'prototype\', \'from\', \'name\'', () => {


### PR DESCRIPTION
* if needs number - method summ all countables values of MyArray;
* if needs string - method return first 5 pairs `key: value`
* by default - method returns `WTF?!`